### PR TITLE
Add palette bank to PND encoding, relax some validation

### DIFF
--- a/libtiled2saturn/tiled2saturn.h
+++ b/libtiled2saturn/tiled2saturn.h
@@ -23,6 +23,7 @@ typedef struct tiled2saturn_tileset {
     uint16_t bpp;
     uint8_t  words_per_palette;
     uint16_t number_of_colors;
+    uint8_t  palette_bank;
     uint32_t palette_size;
     uint8_t* palette;
     uint32_t character_pattern_size;

--- a/src/saturn_layer.rs
+++ b/src/saturn_layer.rs
@@ -72,6 +72,14 @@ impl SaturnLayer {
                                     in_val as u16 & 0x3ff
                                 } else {0};
                             
+                            //  current_tile_index - this is the tileset count we are currently at given all previous tilesets that exist - unless our tile is transparent, increment by index
+                            if tile_id != u32::MAX {
+                                out_val += current_tile_index; 
+                            }
+
+                            // add the palette bank for this number of colors
+                            out_val |= (tileset.palette_bank as u16) << 12;
+
                             // is tile horizontally flipped?
                             if flip_horizontal {
                                 out_val |= 0x400;
@@ -81,23 +89,22 @@ impl SaturnLayer {
                                 out_val |= 0x800;
                             }
                             
-                            //  current_tile_index - this is the tileset count we are currently at given all previous tilesets that exist - unless our tile is transparent, increment by index
-                            if tile_id != u32::MAX {
-                                out_val += current_tile_index; 
-                            }
-                            
                             results.append(&mut out_val.to_be_bytes().to_vec());
                         } else {
                             let mut out_val = (in_val & 0x7fff) << 1;
-                    
+                            
+                            // add the palette bank for this number of colors
+                            out_val |= (tileset.palette_bank as u32) << 16;
+
                             // is tile horizontally flipped?
                             if flip_horizontal {
                                 out_val |= 0x40000000;
                             }
                             // is tile vertically flipped?
-                            if flip_vertical { // Is this a bug from original satconv? verify.
-                                out_val |= 0x40000000;
+                            if flip_vertical { 
+                                out_val |= 0x80000000;
                             }
+
                             results.append(&mut out_val.to_be_bytes().to_vec());
                         }
                     }

--- a/src/saturn_map.rs
+++ b/src/saturn_map.rs
@@ -31,7 +31,7 @@ impl SaturnMapHeader {
     fn new(width: u32, height: u32, tileset_count:u8, tilesets_size: u32, layer_count: u8, layers_size: u32, bitmap_layer_count: u8, bitmap_layers_size: u32) -> Self {
         SaturnMapHeader {
             magic: 0x894D4150, 
-            version: 3, 
+            version: 4, 
             width, 
             height,
             tileset_count,
@@ -60,11 +60,11 @@ pub struct SaturnMap {
 }
 
 impl SaturnMap {
-    pub fn build(map: Map, words_per_pallate: u8) -> Result<SaturnMap, String> {
+    pub fn build(map: Map, words_per_pallete: u8) -> Result<SaturnMap, String> {
         let width = map.width;
         let height = map.height;
 
-        let tilesets = SaturnTileset::build(map.tilesets(), words_per_pallate)?;
+        let tilesets = SaturnTileset::build(map.tilesets(), words_per_pallete)?;
         let tileset_count = u8::try_from(tilesets.len()).map_err(|e| e.to_string())?;
         let tilesets_size: u32 = tilesets.iter().map(|f| f.tileset_size).sum();
 
@@ -72,7 +72,7 @@ impl SaturnMap {
         let layer_count = u8::try_from(layers.len()).map_err(|e| e.to_string())?;
         let layers_size: u32 = layers.iter().map(|f| f.layer_size).sum();
 
-        let bitmap_layers = SaturnBitmapLayer::build(map.layers(), words_per_pallate)?;
+        let bitmap_layers = SaturnBitmapLayer::build(map.layers(), words_per_pallete)?;
         let bitmap_layer_count = u8::try_from(bitmap_layers.len()).map_err(|e| e.to_string())?;
         let bitmap_layers_size = bitmap_layers.iter().map(|f| f.layer_size).sum();
 


### PR DESCRIPTION
This PR resolves palette banks missing from PND and also changes the way we calculate a color bank for an image